### PR TITLE
Fix EQL escaping

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -422,7 +422,7 @@ class ElasticsearchEQLBackend(DeepFieldMappingMixin, ElasticsearchWildcardHandli
     mapExpression = "%s : %s"
     mapListsSpecialHandling = False
     mapListValueExpression = "%s : %s"
-    reEscape = re.compile('(["\\\\])')
+    reEscape = re.compile(r"([\"]|(?<!\\)\\(?![*\\])|\\u|&&|\|\|)")
 
     sort_condition_lists = True
 


### PR DESCRIPTION
### Summary of the Pull Request

Fixes EQL wildcard escaping

### Detailed Description of the Pull Request / Additional Comments

In certain situations, the converted EQL query has backslashes at the end, instead of two.

### Example Log Event

Before fix:

REF: https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_creation/proc_creation_win_susp_calc.yml

`process where (( not (process.executable : ("C:\\Windows\\System32\\\\*","C:\\Windows\\SysWOW64\\\\*","C:\\Windows\\WinSxS\\\\*")) and process.executable : "*\\calc.exe") or process.command_line : "*\\calc.exe *")`
    

After Fix:

`process where (( not (process.executable : ("C:\\Windows\\System32\\*","C:\\Windows\\SysWOW64\\*","C:\\Windows\\WinSxS\\*")) and process.executable : "*\\calc.exe") or process.command_line : "*\\calc.exe *")`

### Fixed Issues

https://github.com/SigmaHQ/legacy-sigmatools/issues/13

### SigmaHQ Rule Creation Conventions

N/A

Thanks to @maederm for the fix.
